### PR TITLE
Fix Windows hook paths and add missing detach definitions

### DIFF
--- a/internal/install/hooks.go
+++ b/internal/install/hooks.go
@@ -5,9 +5,10 @@ import (
 	"fmt"
 	"log/slog"
 	"path/filepath"
+	"runtime"
 
-	"github.com/spf13/afero"
 	"claudio.click/internal/fs"
+	"github.com/spf13/afero"
 )
 
 // HooksMap represents the hooks section of Claude Code settings
@@ -287,9 +288,18 @@ func IsClaudioHook(hookValue interface{}) bool {
 	return false
 }
 
-// GetExecutablePath returns the current executable path using filesystem abstraction
+// GetExecutablePath returns the current executable path using filesystem abstraction.
+// On Windows the result is converted to forward slashes so that the path works
+// when Claude Code invokes the hook command through bash.
 func GetExecutablePath() (string, error) {
-	return fs.ExecutablePath()
+	p, err := fs.ExecutablePath()
+	if err != nil {
+		return "", err
+	}
+	if runtime.GOOS == "windows" {
+		p = filepath.ToSlash(p)
+	}
+	return p, nil
 }
 
 // GetFilesystemFactory returns the default filesystem factory


### PR DESCRIPTION
## Summary

- **Fix Windows hook command paths**: `claudio install` writes the executable path from `os.Executable()` into Claude Code's `settings.json`. On Windows this produces backslash paths (e.g. `C:\Users\foo\go\bin\claudio.exe`). Since Claude Code invokes hooks through `/usr/bin/bash`, the backslashes are interpreted as escape characters, mangling the path into `C:Usersfoogobinclaudio.exe` — causing every hook to fail with "command not found". Fixed by converting to forward slashes via `filepath.ToSlash` on Windows.

- **Add missing `detach.go`**: Commits c77f4e6 and 066f1a1 introduced calls to `shouldDetachHookProcessing()` and `spawnDetachedHookWorker()` but the file containing their definitions was never committed, breaking the build.

## Test plan

- [x] `go test ./...` passes
- [ ] On Windows: run `claudio install`, verify `settings.json` hook paths use forward slashes
- [ ] On Windows: verify hooks fire correctly after install

🤖 Generated with [Claude Code](https://claude.com/claude-code)