### PR TITLE
Demote routine operational logs from INFO to DEBUG

### DIFF
--- a/internal/audio/aiff_decoder.go
+++ b/internal/audio/aiff_decoder.go
@@ -148,7 +148,7 @@ func (d *AiffDecoder) Decode(reader io.Reader) (*AudioData, error) {
 		Format:     malgoFormat,
 	}
 
-	slog.Info("AIFF decode completed successfully",
+	slog.Debug("AIFF decode completed successfully",
 		"total_bytes", len(rawBytes),
 		"total_samples", len(pcmBuffer.Data),
 		"channels", audioData.Channels,

--- a/internal/audio/context.go
+++ b/internal/audio/context.go
@@ -26,7 +26,7 @@ func NewContext() (*Context, error) {
 		return nil, err
 	}
 
-	slog.Info("audio context initialized successfully")
+	slog.Debug("audio context initialized successfully")
 	return &Context{ctx: ctx}, nil
 }
 
@@ -49,7 +49,7 @@ func (c *Context) Close() error {
 	c.ctx.Free()
 	c.ctx = nil
 
-	slog.Info("audio context closed successfully")
+	slog.Debug("audio context closed successfully")
 	return nil
 }
 

--- a/internal/audio/malgo_backend.go
+++ b/internal/audio/malgo_backend.go
@@ -209,7 +209,7 @@ func (mb *MalgoBackend) loadAudioFile(filePath string) (*AudioData, error) {
 		return nil, fmt.Errorf("decode failed: %w", err)
 	}
 
-	slog.Info("audio file loaded successfully via registry",
+	slog.Debug("audio file loaded successfully via registry",
 		"file", filePath,
 		"channels", audioData.Channels,
 		"sample_rate", audioData.SampleRate,
@@ -232,7 +232,7 @@ func (mb *MalgoBackend) loadAudioFromReader(reader io.Reader, format string) (*A
 		return nil, fmt.Errorf("decode from reader failed: %w", err)
 	}
 
-	slog.Info("audio reader loaded successfully via registry",
+	slog.Debug("audio reader loaded successfully via registry",
 		"format", format,
 		"channels", audioData.Channels,
 		"sample_rate", audioData.SampleRate,

--- a/internal/audio/mp3_decoder.go
+++ b/internal/audio/mp3_decoder.go
@@ -89,7 +89,7 @@ func (d *Mp3Decoder) Decode(reader io.Reader) (*AudioData, error) {
 		durationMs = (len(samples) * 1000) / bytesPerSecond
 	}
 
-	slog.Info("MP3 decode completed successfully",
+	slog.Debug("MP3 decode completed successfully",
 		"total_bytes", len(samples),
 		"channels", audioData.Channels,
 		"sample_rate", audioData.SampleRate,

--- a/internal/audio/playback.go
+++ b/internal/audio/playback.go
@@ -132,12 +132,12 @@ func (p *AudioPlayer) PreloadSound(soundID string, audioData *AudioData) error {
 	
 	// Check if we're overwriting an existing sound
 	if _, exists := p.sounds[soundID]; exists {
-		slog.Info("overwriting existing preloaded sound", "sound_id", soundID)
+		slog.Debug("overwriting existing preloaded sound", "sound_id", soundID)
 	}
 	
 	p.sounds[soundID] = audioData
 	
-	slog.Info("sound preloaded successfully", 
+	slog.Debug("sound preloaded successfully",
 		"sound_id", soundID,
 		"total_preloaded", len(p.sounds))
 	
@@ -160,7 +160,7 @@ func (p *AudioPlayer) UnloadSound(soundID string) error {
 	
 	delete(p.sounds, soundID)
 	
-	slog.Info("sound unloaded successfully", 
+	slog.Debug("sound unloaded successfully",
 		"sound_id", soundID,
 		"remaining_preloaded", len(p.sounds))
 	
@@ -358,7 +358,7 @@ func (p *AudioPlayer) PlaySoundWithContext(ctx context.Context, soundID string) 
 	p.isPlaying = stillPlaying
 	p.mutex.Unlock()
 	
-	slog.Info("sound playback cleanup completed", "sound_id", soundID, "still_playing", stillPlaying)
+	slog.Debug("sound playback cleanup completed", "sound_id", soundID, "still_playing", stillPlaying)
 	return nil
 }
 
@@ -370,7 +370,7 @@ func (p *AudioPlayer) Stop() error {
 	p.isPlaying = false
 	p.mutex.Unlock()
 	
-	slog.Info("sound playback stopped")
+	slog.Debug("sound playback stopped")
 	return nil
 }
 

--- a/internal/audio/registry.go
+++ b/internal/audio/registry.go
@@ -36,7 +36,7 @@ func NewDefaultRegistry() *DecoderRegistry {
 	registry.Register(NewMp3Decoder())
 	registry.Register(NewAiffDecoder())
 
-	slog.Info("default decoder registry initialized",
+	slog.Debug("default decoder registry initialized",
 		"supported_formats", registry.GetSupportedFormats())
 
 	return registry
@@ -54,7 +54,7 @@ func (r *DecoderRegistry) Register(decoder Decoder) {
 
 	r.decoders = append(r.decoders, decoder)
 
-	slog.Info("decoder registered successfully",
+	slog.Debug("decoder registered successfully",
 		"format", formatName,
 		"total_decoders", len(r.decoders))
 }
@@ -150,7 +150,7 @@ func (r *DecoderRegistry) DetectFormatWithContent(filename string, reader io.Rea
 
 	// If magic detection succeeded, use it (this takes precedence over extension)
 	if formatDecoder != nil {
-		slog.Info("format detected by magic bytes",
+		slog.Debug("format detected by magic bytes",
 			"filename", filename,
 			"detected_format", formatDecoder.FormatName(),
 			"mime_type", detectedMime)
@@ -162,7 +162,7 @@ func (r *DecoderRegistry) DetectFormatWithContent(filename string, reader io.Rea
 	extensionDecoder := r.DetectFormat(filename)
 
 	if extensionDecoder != nil {
-		slog.Info("format detected by extension fallback",
+		slog.Debug("format detected by extension fallback",
 			"filename", filename,
 			"format", extensionDecoder.FormatName())
 	} else {
@@ -204,7 +204,7 @@ func (r *DecoderRegistry) DecodeFile(filename string, reader io.Reader) (*AudioD
 		return nil, err
 	}
 
-	slog.Info("decoder selected for file",
+	slog.Debug("decoder selected for file",
 		"filename", filename,
 		"decoder_format", decoder.FormatName())
 
@@ -219,7 +219,7 @@ func (r *DecoderRegistry) DecodeFile(filename string, reader io.Reader) (*AudioD
 		return nil, err
 	}
 
-	slog.Info("file decode completed successfully",
+	slog.Debug("file decode completed successfully",
 		"filename", filename,
 		"decoder_format", decoder.FormatName(),
 		"channels", audioData.Channels,

--- a/internal/audio/wav_decoder.go
+++ b/internal/audio/wav_decoder.go
@@ -139,7 +139,7 @@ func (d *WavDecoder) Decode(reader io.Reader) (*AudioData, error) {
 		Format:     malgoFormat,
 	}
 
-	slog.Info("WAV decode completed successfully",
+	slog.Debug("WAV decode completed successfully",
 		"total_bytes", len(rawBytes),
 		"total_samples", len(allSamples),
 		"channels", audioData.Channels,

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -234,7 +234,7 @@ func initializeAudioSystem(cmd *cobra.Command, cli *CLI, cfg *config.Config) err
 					base := filepath.Base(sp)
 					name := strings.TrimSuffix(base, filepath.Ext(base))
 					if name == cfg.DefaultSoundpack {
-						slog.Info("resolved soundpack name to path",
+						slog.Debug("resolved soundpack name to path",
 							"name", cfg.DefaultSoundpack, "path", sp)
 						resolvedPath = sp
 						break
@@ -245,7 +245,7 @@ func initializeAudioSystem(cmd *cobra.Command, cli *CLI, cfg *config.Config) err
 
 		// Check if resolved soundpack path exists
 		if _, statErr := os.Stat(resolvedPath); statErr != nil {
-			slog.Info("configured soundpack not found, will try platform fallback",
+			slog.Debug("configured soundpack not found, will try platform fallback",
 				"soundpack", cfg.DefaultSoundpack, "resolved", resolvedPath, "error", statErr)
 			shouldTryPlatformFallback = true
 		}
@@ -273,7 +273,7 @@ func initializeAudioSystem(cmd *cobra.Command, cli *CLI, cfg *config.Config) err
 		platformSoundpack := cfgMgr.GetPlatformSoundpack(afero.NewOsFs(), execDir)
 
 		if platformSoundpack != "default" {
-			slog.Info("using platform-specific soundpack", "path", platformSoundpack)
+			slog.Debug("using platform-specific soundpack", "path", platformSoundpack)
 
 			var platformMapper soundpack.PathMapper
 			var platformErr error
@@ -291,7 +291,7 @@ func initializeAudioSystem(cmd *cobra.Command, cli *CLI, cfg *config.Config) err
 			}
 
 			if platformErr == nil {
-				slog.Info("platform soundpack loaded successfully", "identifier", platformSoundpack)
+				slog.Debug("platform soundpack loaded successfully", "identifier", platformSoundpack)
 				mapper = platformMapper
 			} else {
 				slog.Warn("platform soundpack failed to load",
@@ -573,7 +573,7 @@ func (c *CLI) processHookEvent(hookEvent *hooks.HookEvent, cfg *config.Config, s
 	// Extract hook context directly from event
 	context := hookEvent.GetContext()
 
-	slog.Info("hook context parsed",
+	slog.Debug("hook context parsed",
 		"category", context.Category.String(),
 		"operation", context.Operation,
 		"tool", context.ToolName,
@@ -600,7 +600,7 @@ func (c *CLI) processHookEvent(hookEvent *hooks.HookEvent, cfg *config.Config, s
 		return
 	}
 
-	slog.Info("sound mapped",
+	slog.Debug("sound mapped",
 		"fallback_level", result.FallbackLevel,
 		"total_paths", result.TotalPaths,
 		"selected_path", result.SelectedPath)
@@ -617,7 +617,7 @@ func (c *CLI) processHookEvent(hookEvent *hooks.HookEvent, cfg *config.Config, s
 			slog.Error("sound playback failed", "sound_path", result.SelectedPath, "error", err)
 			return
 		}
-		slog.Info("sound played successfully", "sound_path", result.SelectedPath)
+		slog.Debug("sound played successfully", "sound_path", result.SelectedPath)
 	} else {
 		slog.Debug("audio disabled, skipping sound playback")
 	}
@@ -648,7 +648,7 @@ func (c *CLI) playSoundWithBackend(soundPath string, volume float64) error {
 		return fmt.Errorf("failed to play sound with backend: %w", err)
 	}
 
-	slog.Info("sound playback completed successfully", "path", soundPath, "backend_type", fmt.Sprintf("%T", c.audioBackend))
+	slog.Debug("sound playback completed successfully", "path", soundPath, "backend_type", fmt.Sprintf("%T", c.audioBackend))
 	return nil
 }
 
@@ -838,6 +838,6 @@ func loadEmbeddedPlatformSoundpack(identifier string) (soundpack.PathMapper, err
 		return nil, fmt.Errorf("failed to load embedded platform soundpack: %w", err)
 	}
 
-	slog.Info("embedded platform soundpack loaded successfully", "filename", filename)
+	slog.Debug("embedded platform soundpack loaded successfully", "filename", filename)
 	return mapper, nil
 }

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -227,7 +227,7 @@ func initializeAudioSystem(cmd *cobra.Command, cli *CLI, cfg *config.Config) err
 					base := filepath.Base(sp)
 					name := strings.TrimSuffix(base, filepath.Ext(base))
 					if name == cfg.DefaultSoundpack {
-						slog.Info("resolved soundpack name to path",
+						slog.Debug("resolved soundpack name to path",
 							"name", cfg.DefaultSoundpack, "path", sp)
 						resolvedPath = sp
 						break
@@ -238,7 +238,7 @@ func initializeAudioSystem(cmd *cobra.Command, cli *CLI, cfg *config.Config) err
 
 		// Check if resolved soundpack path exists
 		if _, statErr := os.Stat(resolvedPath); statErr != nil {
-			slog.Info("configured soundpack not found, will try platform fallback",
+			slog.Debug("configured soundpack not found, will try platform fallback",
 				"soundpack", cfg.DefaultSoundpack, "resolved", resolvedPath, "error", statErr)
 			shouldTryPlatformFallback = true
 		}
@@ -266,7 +266,7 @@ func initializeAudioSystem(cmd *cobra.Command, cli *CLI, cfg *config.Config) err
 		platformSoundpack := cfgMgr.GetPlatformSoundpack(afero.NewOsFs(), execDir)
 
 		if platformSoundpack != "default" {
-			slog.Info("using platform-specific soundpack", "path", platformSoundpack)
+			slog.Debug("using platform-specific soundpack", "path", platformSoundpack)
 
 			var platformMapper soundpack.PathMapper
 			var platformErr error
@@ -284,7 +284,7 @@ func initializeAudioSystem(cmd *cobra.Command, cli *CLI, cfg *config.Config) err
 			}
 
 			if platformErr == nil {
-				slog.Info("platform soundpack loaded successfully", "identifier", platformSoundpack)
+				slog.Debug("platform soundpack loaded successfully", "identifier", platformSoundpack)
 				mapper = platformMapper
 			} else {
 				slog.Warn("platform soundpack failed to load",
@@ -566,7 +566,7 @@ func (c *CLI) processHookEvent(hookEvent *hooks.HookEvent, cfg *config.Config, s
 	// Extract hook context directly from event
 	context := hookEvent.GetContext()
 
-	slog.Info("hook context parsed",
+	slog.Debug("hook context parsed",
 		"category", context.Category.String(),
 		"operation", context.Operation,
 		"tool", context.ToolName,
@@ -593,7 +593,7 @@ func (c *CLI) processHookEvent(hookEvent *hooks.HookEvent, cfg *config.Config, s
 		return
 	}
 
-	slog.Info("sound mapped",
+	slog.Debug("sound mapped",
 		"fallback_level", result.FallbackLevel,
 		"total_paths", result.TotalPaths,
 		"selected_path", result.SelectedPath)
@@ -610,7 +610,7 @@ func (c *CLI) processHookEvent(hookEvent *hooks.HookEvent, cfg *config.Config, s
 			slog.Error("sound playback failed", "sound_path", result.SelectedPath, "error", err)
 			return
 		}
-		slog.Info("sound played successfully", "sound_path", result.SelectedPath)
+		slog.Debug("sound played successfully", "sound_path", result.SelectedPath)
 	} else {
 		slog.Debug("audio disabled, skipping sound playback")
 	}
@@ -641,7 +641,7 @@ func (c *CLI) playSoundWithBackend(soundPath string, volume float64) error {
 		return fmt.Errorf("failed to play sound with backend: %w", err)
 	}
 
-	slog.Info("sound playback completed successfully", "path", soundPath, "backend_type", fmt.Sprintf("%T", c.audioBackend))
+	slog.Debug("sound playback completed successfully", "path", soundPath, "backend_type", fmt.Sprintf("%T", c.audioBackend))
 	return nil
 }
 
@@ -831,6 +831,6 @@ func loadEmbeddedPlatformSoundpack(identifier string) (soundpack.PathMapper, err
 		return nil, fmt.Errorf("failed to load embedded platform soundpack: %w", err)
 	}
 
-	slog.Info("embedded platform soundpack loaded successfully", "filename", filename)
+	slog.Debug("embedded platform soundpack loaded successfully", "filename", filename)
 	return mapper, nil
 }

--- a/internal/hooks/parser.go
+++ b/internal/hooks/parser.go
@@ -127,7 +127,7 @@ func (p *HookEventParser) Parse(data []byte) (*HookEvent, error) {
 		return nil, err
 	}
 
-	slog.Info("hook event parsed successfully",
+	slog.Debug("hook event parsed successfully",
 		"event_name", event.EventName,
 		"session_id", event.SessionID,
 		"tool_name", getStringPtr(event.ToolName),
@@ -306,7 +306,7 @@ func (e *HookEvent) GetContext() *EventContext {
 		context.FileType = e.extractFileType()
 	}
 
-	slog.Info("event context extracted",
+	slog.Debug("event context extracted",
 		"event_name", e.EventName,
 		"category", context.Category.String(),
 		"sound_hint", context.SoundHint,

--- a/internal/hooks/parser.go
+++ b/internal/hooks/parser.go
@@ -127,7 +127,7 @@ func (p *HookEventParser) Parse(data []byte) (*HookEvent, error) {
 		return nil, err
 	}
 
-	slog.Info("hook event parsed successfully",
+	slog.Debug("hook event parsed successfully",
 		"event_name", event.EventName,
 		"session_id", event.SessionID,
 		"tool_name", getStringPtr(event.ToolName),
@@ -322,7 +322,7 @@ func (e *HookEvent) GetContext() *EventContext {
 		context.FileType = e.extractFileType()
 	}
 
-	slog.Info("event context extracted",
+	slog.Debug("event context extracted",
 		"event_name", e.EventName,
 		"category", context.Category.String(),
 		"sound_hint", context.SoundHint,

--- a/internal/soundpack/soundpack.go
+++ b/internal/soundpack/soundpack.go
@@ -72,7 +72,7 @@ func (u *UnifiedSoundpackResolver) ResolveSound(relativePath string) (string, er
 		slog.Debug("checking candidate", "index", i, "candidate", candidate)
 
 		if _, err := os.Stat(candidate); err == nil {
-			slog.Info("sound path resolved successfully",
+			slog.Debug("sound path resolved successfully",
 				"relative_path", relativePath,
 				"resolved_path", candidate,
 				"mapper_type", u.mapper.GetType(),
@@ -116,7 +116,7 @@ func (u *UnifiedSoundpackResolver) ResolveSoundWithFallback(paths []string) (str
 
 		resolved, err := u.ResolveSound(path)
 		if err == nil {
-			slog.Info("fallback resolution successful",
+			slog.Debug("fallback resolution successful",
 				"resolved_path", resolved,
 				"fallback_index", i,
 				"fallback_path", path,
@@ -210,7 +210,7 @@ func LoadJSONSoundpack(filePath string) (PathMapper, error) {
 		"name", soundpack.Name,
 		"mappings_count", len(soundpack.Mappings))
 
-	slog.Info("JSON soundpack loaded successfully",
+	slog.Debug("JSON soundpack loaded successfully",
 		"file_path", filePath,
 		"name", soundpack.Name,
 		"valid_mappings", len(soundpack.Mappings))
@@ -286,7 +286,7 @@ func LoadJSONSoundpackFromBytes(data []byte) (PathMapper, error) {
 		"name", soundpack.Name,
 		"mappings_count", len(soundpack.Mappings))
 
-	slog.Info("JSON soundpack loaded successfully from bytes",
+	slog.Debug("JSON soundpack loaded successfully from bytes",
 		"name", soundpack.Name,
 		"valid_mappings", len(soundpack.Mappings))
 
@@ -350,7 +350,7 @@ func CreateSoundpackMapperWithBasePaths(name, primaryPath string, basePaths []st
 	}
 
 	// Create directory mapper with base paths for fallback
-	slog.Info("creating directory mapper with base paths",
+	slog.Debug("creating directory mapper with base paths",
 		"name", name,
 		"base_paths", basePaths)
 

--- a/internal/soundpack/soundpack.go
+++ b/internal/soundpack/soundpack.go
@@ -71,7 +71,7 @@ func (u *UnifiedSoundpackResolver) ResolveSound(relativePath string) (string, er
 		slog.Debug("checking candidate", "index", i, "candidate", candidate)
 
 		if _, err := os.Stat(candidate); err == nil {
-			slog.Info("sound path resolved successfully",
+			slog.Debug("sound path resolved successfully",
 				"relative_path", relativePath,
 				"resolved_path", candidate,
 				"mapper_type", u.mapper.GetType(),
@@ -115,7 +115,7 @@ func (u *UnifiedSoundpackResolver) ResolveSoundWithFallback(paths []string) (str
 
 		resolved, err := u.ResolveSound(path)
 		if err == nil {
-			slog.Info("fallback resolution successful",
+			slog.Debug("fallback resolution successful",
 				"resolved_path", resolved,
 				"fallback_index", i,
 				"fallback_path", path,
@@ -207,7 +207,7 @@ func LoadJSONSoundpack(filePath string) (PathMapper, error) {
 		"name", soundpack.Name,
 		"mappings_count", len(soundpack.Mappings))
 
-	slog.Info("JSON soundpack loaded successfully",
+	slog.Debug("JSON soundpack loaded successfully",
 		"file_path", filePath,
 		"name", soundpack.Name,
 		"valid_mappings", len(soundpack.Mappings))
@@ -268,7 +268,7 @@ func LoadJSONSoundpackFromBytes(data []byte) (PathMapper, error) {
 		"name", soundpack.Name,
 		"mappings_count", len(soundpack.Mappings))
 
-	slog.Info("JSON soundpack loaded successfully from bytes",
+	slog.Debug("JSON soundpack loaded successfully from bytes",
 		"name", soundpack.Name,
 		"valid_mappings", len(soundpack.Mappings))
 
@@ -332,7 +332,7 @@ func CreateSoundpackMapperWithBasePaths(name, primaryPath string, basePaths []st
 	}
 
 	// Create directory mapper with base paths for fallback
-	slog.Info("creating directory mapper with base paths",
+	slog.Debug("creating directory mapper with base paths",
 		"name", name,
 		"base_paths", basePaths)
 

--- a/internal/sounds/mapper.go
+++ b/internal/sounds/mapper.go
@@ -211,7 +211,7 @@ func (m *SoundMapper) mapEnhancedSound(context *hooks.EventContext) *SoundMappin
 		ChainType:     ChainTypeEnhanced,
 	}
 
-	slog.Info("enhanced sound mapping completed",
+	slog.Debug("enhanced sound mapping completed",
 		"selected_path", result.SelectedPath,
 		"fallback_level", result.FallbackLevel,
 		"total_paths", result.TotalPaths,
@@ -462,7 +462,7 @@ func (m *SoundMapper) mapPostToolSound(context *hooks.EventContext) *SoundMappin
 		ChainType:     ChainTypePostTool,
 	}
 
-	slog.Info("PostToolUse sound mapping completed",
+	slog.Debug("PostToolUse sound mapping completed",
 		"selected_path", result.SelectedPath,
 		"fallback_level", result.FallbackLevel,
 		"total_paths", result.TotalPaths,
@@ -531,7 +531,7 @@ func (m *SoundMapper) mapSimpleSound(context *hooks.EventContext) *SoundMappingR
 		ChainType:     ChainTypeSimple,
 	}
 
-	slog.Info("simple sound mapping completed",
+	slog.Debug("simple sound mapping completed",
 		"selected_path", result.SelectedPath,
 		"fallback_level", result.FallbackLevel,
 		"total_paths", result.TotalPaths,
@@ -625,7 +625,7 @@ func (m *SoundMapper) mapLegacySound(context *hooks.EventContext) *SoundMappingR
 		ChainType:     chainType,
 	}
 
-	slog.Info("legacy sound mapping completed",
+	slog.Debug("legacy sound mapping completed",
 		"selected_path", result.SelectedPath,
 		"fallback_level", result.FallbackLevel,
 		"total_paths", result.TotalPaths,


### PR DESCRIPTION
## Summary

- Moves per-invocation internal detail logs to DEBUG across `audio`, `cli`, `hooks`, `soundpack`, and `sounds` packages
- These logs fired on every hook call and created noise at the default `warn` level
- Keeps meaningful startup signals (tracking DB init, hook event name, config test mode) at INFO

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] Binary builds and runs correctly (`./claudio --version`)
- [x] Silent mode smoke test passes
- [x] No behavior changes — purely log level demotion

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Sonnet 4.6)