### PR TITLE
feat: Normalize mcp__<server>__<tool> names to 'mcp' for sound mapping

### DIFF
--- a/internal/hooks/parser.go
+++ b/internal/hooks/parser.go
@@ -178,6 +178,10 @@ func (e *HookEvent) GetContext() *EventContext {
 				// Fallback to original behavior
 				context.SoundHint = strings.ToLower(context.ToolName) + "-start"
 			}
+		} else if strings.HasPrefix(context.ToolName, "mcp__") {
+			context.OriginalTool = context.ToolName
+			context.ToolName = "mcp"
+			context.SoundHint = "mcp-start"
 		} else if context.ToolName != "" {
 			context.SoundHint = strings.ToLower(context.ToolName) + "-start"
 		} else {
@@ -216,6 +220,10 @@ func (e *HookEvent) GetContext() *EventContext {
 						context.SoundHint = strings.ToLower(context.ToolName) + "-error"
 					}
 				}
+			} else if strings.HasPrefix(context.ToolName, "mcp__") {
+				context.OriginalTool = context.ToolName
+				context.ToolName = "mcp"
+				context.SoundHint = "mcp-error"
 			} else {
 				// Original logic for non-Bash tools
 				if errorType != "" {
@@ -246,6 +254,10 @@ func (e *HookEvent) GetContext() *EventContext {
 					// Fallback to original behavior
 					context.SoundHint = strings.ToLower(context.ToolName) + "-success"
 				}
+			} else if strings.HasPrefix(context.ToolName, "mcp__") {
+				context.OriginalTool = context.ToolName
+				context.ToolName = "mcp"
+				context.SoundHint = "mcp-success"
 			} else {
 				// Original logic for non-Bash tools
 				if context.ToolName != "" {
@@ -340,6 +352,12 @@ func (e *HookEvent) analyzeToolResponse() (success bool, hasError bool, errorTyp
 	if interrupted, ok := response["interrupted"].(bool); ok && interrupted {
 		slog.Debug("tool was interrupted")
 		return false, true, "tool-interrupted"
+	}
+
+	// Check for MCP-style isError field
+	if isError, ok := response["isError"].(bool); ok && isError {
+		slog.Debug("tool response has isError=true (MCP error)")
+		return false, true, ""
 	}
 
 	// Check for common error indicators

--- a/internal/hooks/parser_test.go
+++ b/internal/hooks/parser_test.go
@@ -1124,3 +1124,151 @@ func TestPostToolUseSuffixesUnchanged(t *testing.T) {
 		})
 	}
 }
+
+// TestMCPToolNormalization verifies that mcp__<server>__<tool> tool names are
+// normalized to "mcp" for sound mapping, making all MCP servers produce the
+// same generic mcp sounds regardless of which server or tool is called.
+func TestMCPToolNormalization(t *testing.T) {
+	parser := NewHookEventParser()
+
+	t.Run("PreToolUse mcp__context7__query-docs normalizes to mcp", func(t *testing.T) {
+		data := `{
+			"session_id": "test",
+			"transcript_path": "/test",
+			"cwd": "/test",
+			"hook_event_name": "PreToolUse",
+			"tool_name": "mcp__context7__query-docs",
+			"tool_input": {}
+		}`
+		event, err := parser.Parse([]byte(data))
+		if err != nil {
+			t.Fatalf("Parse failed: %v", err)
+		}
+		ctx := event.GetContext()
+
+		if ctx.ToolName != "mcp" {
+			t.Errorf("ToolName: expected 'mcp', got '%s'", ctx.ToolName)
+		}
+		if ctx.OriginalTool != "mcp__context7__query-docs" {
+			t.Errorf("OriginalTool: expected 'mcp__context7__query-docs', got '%s'", ctx.OriginalTool)
+		}
+		if ctx.SoundHint != "mcp-start" {
+			t.Errorf("SoundHint: expected 'mcp-start', got '%s'", ctx.SoundHint)
+		}
+		if ctx.Category != Loading {
+			t.Errorf("Category: expected Loading, got %s", ctx.Category.String())
+		}
+	})
+
+	t.Run("PreToolUse mcp__filesystem__read_file normalizes to mcp", func(t *testing.T) {
+		data := `{
+			"session_id": "test",
+			"transcript_path": "/test",
+			"cwd": "/test",
+			"hook_event_name": "PreToolUse",
+			"tool_name": "mcp__filesystem__read_file",
+			"tool_input": {}
+		}`
+		event, err := parser.Parse([]byte(data))
+		if err != nil {
+			t.Fatalf("Parse failed: %v", err)
+		}
+		ctx := event.GetContext()
+
+		if ctx.ToolName != "mcp" {
+			t.Errorf("ToolName: expected 'mcp', got '%s'", ctx.ToolName)
+		}
+		if ctx.OriginalTool != "mcp__filesystem__read_file" {
+			t.Errorf("OriginalTool: expected 'mcp__filesystem__read_file', got '%s'", ctx.OriginalTool)
+		}
+		if ctx.SoundHint != "mcp-start" {
+			t.Errorf("SoundHint: expected 'mcp-start', got '%s'", ctx.SoundHint)
+		}
+	})
+
+	t.Run("PostToolUse success mcp__github__create_issue normalizes to mcp-success", func(t *testing.T) {
+		data := `{
+			"session_id": "test",
+			"transcript_path": "/test",
+			"cwd": "/test",
+			"hook_event_name": "PostToolUse",
+			"tool_name": "mcp__github__create_issue",
+			"tool_input": {},
+			"tool_response": {"content": "issue created", "isError": false}
+		}`
+		event, err := parser.Parse([]byte(data))
+		if err != nil {
+			t.Fatalf("Parse failed: %v", err)
+		}
+		ctx := event.GetContext()
+
+		if ctx.ToolName != "mcp" {
+			t.Errorf("ToolName: expected 'mcp', got '%s'", ctx.ToolName)
+		}
+		if ctx.OriginalTool != "mcp__github__create_issue" {
+			t.Errorf("OriginalTool: expected 'mcp__github__create_issue', got '%s'", ctx.OriginalTool)
+		}
+		if ctx.SoundHint != "mcp-success" {
+			t.Errorf("SoundHint: expected 'mcp-success', got '%s'", ctx.SoundHint)
+		}
+		if ctx.Category != Success {
+			t.Errorf("Category: expected Success, got %s", ctx.Category.String())
+		}
+	})
+
+	t.Run("PostToolUse error mcp__slack__send_message normalizes to mcp-error", func(t *testing.T) {
+		data := `{
+			"session_id": "test",
+			"transcript_path": "/test",
+			"cwd": "/test",
+			"hook_event_name": "PostToolUse",
+			"tool_name": "mcp__slack__send_message",
+			"tool_input": {},
+			"tool_response": {"content": "rate limited", "isError": true}
+		}`
+		event, err := parser.Parse([]byte(data))
+		if err != nil {
+			t.Fatalf("Parse failed: %v", err)
+		}
+		ctx := event.GetContext()
+
+		if ctx.ToolName != "mcp" {
+			t.Errorf("ToolName: expected 'mcp', got '%s'", ctx.ToolName)
+		}
+		if ctx.OriginalTool != "mcp__slack__send_message" {
+			t.Errorf("OriginalTool: expected 'mcp__slack__send_message', got '%s'", ctx.OriginalTool)
+		}
+		if ctx.SoundHint != "mcp-error" {
+			t.Errorf("SoundHint: expected 'mcp-error', got '%s'", ctx.SoundHint)
+		}
+		if ctx.Category != Error {
+			t.Errorf("Category: expected Error, got %s", ctx.Category.String())
+		}
+	})
+
+	t.Run("non-MCP tool is unaffected", func(t *testing.T) {
+		data := `{
+			"session_id": "test",
+			"transcript_path": "/test",
+			"cwd": "/test",
+			"hook_event_name": "PreToolUse",
+			"tool_name": "Read",
+			"tool_input": {}
+		}`
+		event, err := parser.Parse([]byte(data))
+		if err != nil {
+			t.Fatalf("Parse failed: %v", err)
+		}
+		ctx := event.GetContext()
+
+		if ctx.ToolName != "Read" {
+			t.Errorf("ToolName: expected 'Read', got '%s'", ctx.ToolName)
+		}
+		if ctx.OriginalTool != "" {
+			t.Errorf("OriginalTool: expected empty for non-MCP tool, got '%s'", ctx.OriginalTool)
+		}
+		if ctx.SoundHint != "read-start" {
+			t.Errorf("SoundHint: expected 'read-start', got '%s'", ctx.SoundHint)
+		}
+	})
+}


### PR DESCRIPTION
## What this does

MCP tool names in Claude Code follow the pattern \`mcp__<server>__<tool>\` (e.g. \`mcp__context7__query-docs\`, \`mcp__filesystem__read_file\`). Before this fix, these were passed through \`normalizeName()\` unchanged, producing paths like \`loading/mcp--context7--query-docs-start.wav\` which never matched anything and silently fell through to \`default.wav\`.

This fix detects any tool name starting with \`mcp__\` and normalizes it to \`mcp\`, setting \`OriginalTool\` to preserve the full name for future per-server fallback. All three hook phases are handled:

- **PreToolUse** → \`mcp-start\`
- **PostToolUse success** → \`mcp-success\`  
- **PostToolUse error** → \`mcp-error\`

Also adds detection of \`isError: true\` in tool responses (the MCP error format), which was previously unrecognized and caused MCP errors to be reported as successes.

## Works for all MCP servers

Any MCP server routes to the same generic sounds regardless of server name or tool:
- \`mcp__context7__query-docs\` → \`mcp\`
- \`mcp__filesystem__read_file\` → \`mcp\`
- \`mcp__github__create_issue\` → \`mcp\`
- \`mcp__your-custom-server__any-tool\` → \`mcp\`

## Test plan

**Automated (TDD):**
- Wrote 5 failing tests in \`TestMCPToolNormalization\` covering context7, filesystem, github, and slack servers, plus a regression test confirming non-MCP tools are unaffected
- Saw all 4 MCP tests fail before implementation, all 5 pass after
- Full test suite green: \`go test ./...\`

**Manual (tested by @blindndangerous):**
- Built binary and installed to \`go/bin\`
- Piped fake \`PreToolUse\` and \`PostToolUse\` hook JSON with \`tool_name: "mcp__context7__query-docs"\` directly into claudio
- Heard the correct Windows sounds fire for both loading and success — confirmed working end-to-end with real audio playback

## Changes

- \`internal/hooks/parser.go\`: MCP prefix detection in PreToolUse and PostToolUse, \`isError\` response detection
- \`internal/hooks/parser_test.go\`: \`TestMCPToolNormalization\` with 5 test cases

🤖 Co-authored with [Claude Sonnet 4.6](https://claude.ai/code)